### PR TITLE
Added production secret validation and proxy support.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ EXPOSE 5054 9181 9182
 CMD sh -c "rq worker --url $REDIS_URL booking_tasks & \
            rq-dashboard --redis-url $REDIS_URL --port 9181 & \
            (while true; do rqscheduler --url $REDIS_URL --interval 60; echo 'rqscheduler crashed, restarting in 5s'; sleep 5; done) & \
-           exec gunicorn -k eventlet -w 1 'app:app' -b 0.0.0.0:5054 --timeout 120"
+           exec gunicorn -k eventlet -w ${GUNICORN_WORKERS:-1} 'app:app' -b 0.0.0.0:${PORT:-5054} --timeout ${GUNICORN_TIMEOUT:-120} --graceful-timeout ${GUNICORN_GRACEFUL_TIMEOUT:-30} --keep-alive ${GUNICORN_KEEPALIVE:-5} --max-requests ${GUNICORN_MAX_REQUESTS:-1000} --max-requests-jitter ${GUNICORN_MAX_REQUESTS_JITTER:-100}"

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -16,19 +16,53 @@ import logging
 import os
 import time
 import uuid
+from werkzeug.middleware.proxy_fix import ProxyFix
 
 # Allow all origins for SocketIO
 socketio = SocketIO(
     async_mode="eventlet",
     cors_allowed_origins="*",
+    ping_interval=int(os.getenv("SOCKETIO_PING_INTERVAL_SEC", "25") or 25),
+    ping_timeout=int(os.getenv("SOCKETIO_PING_TIMEOUT_SEC", "60") or 60),
+    max_http_buffer_size=int(os.getenv("SOCKETIO_MAX_HTTP_BUFFER_BYTES", str(1_000_000)) or 1_000_000),
     logger=os.getenv("SOCKETIO_LOGGER", "false").lower() == "true",
     engineio_logger=os.getenv("ENGINEIO_LOGGER", "false").lower() == "true"
 )
+
+def _is_insecure_secret(value: str, placeholders: set[str]) -> bool:
+    if not value:
+        return True
+    candidate = str(value).strip()
+    if candidate in placeholders:
+        return True
+    return len(candidate) < 32
+
+
+def _validate_production_config(app: Flask) -> None:
+    app_env = str(app.config.get("APP_ENV", "development")).lower()
+    is_production = app_env in {"prod", "production"}
+    if not is_production:
+        return
+    weak_secret = _is_insecure_secret(
+        app.config.get("SECRET_KEY", ""),
+        {"dev-secret-change-me", "changeme"},
+    )
+    weak_jwt_secret = _is_insecure_secret(
+        app.config.get("JWT_SECRET_KEY", ""),
+        {"dev-jwt-secret-change-me", "dev", "changeme"},
+    )
+    if weak_secret or weak_jwt_secret:
+        raise RuntimeError(
+            "In production, SECRET_KEY and JWT_SECRET_KEY must be strong non-default values with length >= 32."
+        )
 
 
 def create_app():
     app = Flask(__name__)
     app.config.from_object(Config)
+    _validate_production_config(app)
+    if app.config.get("TRUST_PROXY", True):
+        app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1, x_host=1, x_port=1)
     app.json.sort_keys = False
     app.json.compact = True
 
@@ -40,7 +74,7 @@ def create_app():
     CORS(
         app,
         resources={r"/*": {
-            "origins": "*",
+            "origins": app.config.get("CORS_ALLOWED_ORIGINS", "*"),
             "allow_headers": "*",
             "methods": ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
             "expose_headers": ["Content-Type", "Authorization"],
@@ -130,7 +164,11 @@ def create_app():
     scheduler = Scheduler(queue=queue, connection=redis_conn)
     app.extensions["scheduler"] = scheduler
 
-    socketio.init_app(app, message_queue=app.config["REDIS_URL"])
+    socketio.init_app(
+        app,
+        message_queue=app.config["REDIS_URL"],
+        cors_allowed_origins=app.config.get("CORS_ALLOWED_ORIGINS", "*"),
+    )
     register_socketio_events(socketio)
 
     return app

--- a/app/config.py
+++ b/app/config.py
@@ -2,6 +2,7 @@ import os
 from services.config_load import load_key_from_file
 
 class Config:
+    APP_ENV = os.getenv("APP_ENV", os.getenv("FLASK_ENV", "development")).lower()
     SECRET_KEY = os.getenv("SECRET_KEY", "dev-secret-change-me")
     JWT_SECRET_KEY = os.getenv("JWT_SECRET_KEY", "dev-jwt-secret-change-me")
     DEBUG = os.getenv("DEBUG_MODE", "false").lower() == "true"
@@ -76,6 +77,8 @@ class Config:
     API_SLOW_REQUEST_MS = int(os.getenv("API_SLOW_REQUEST_MS", "120") or 120)
     API_PUBLIC_CACHE_CONTROL = os.getenv("API_PUBLIC_CACHE_CONTROL", "public, max-age=15, stale-while-revalidate=30")
     API_PRIVATE_CACHE_CONTROL = os.getenv("API_PRIVATE_CACHE_CONTROL", "no-store")
+    TRUST_PROXY = os.getenv("TRUST_PROXY", "true").lower() in ("true", "1", "t", "yes", "y")
+    CORS_ALLOWED_ORIGINS = os.getenv("CORS_ALLOWED_ORIGINS", "*")
 
     # Endpoint-level read microcache profiles
     READ_MICROCACHE_MAX_ITEMS = int(os.getenv("READ_MICROCACHE_MAX_ITEMS", "25000") or 25000)
@@ -90,3 +93,7 @@ class Config:
 
     # Bound user bookings payload size for consistent latency
     USER_BOOKINGS_MAX_ITEMS = int(os.getenv("USER_BOOKINGS_MAX_ITEMS", "120") or 120)
+
+    SOCKETIO_PING_INTERVAL_SEC = int(os.getenv("SOCKETIO_PING_INTERVAL_SEC", "25") or 25)
+    SOCKETIO_PING_TIMEOUT_SEC = int(os.getenv("SOCKETIO_PING_TIMEOUT_SEC", "60") or 60)
+    SOCKETIO_MAX_HTTP_BUFFER_BYTES = int(os.getenv("SOCKETIO_MAX_HTTP_BUFFER_BYTES", str(1_000_000)) or 1_000_000)


### PR DESCRIPTION
Added env-driven CORS origin handling.

Added Socket.IO tuning env vars and init settings.

Gunicorn eventlet runtime made env-tunable.

Files: config.py, init.py, Dockerfile

hash-dashboard/docs

Updated base URL ownership mapping with service directories + websocket ownership.

Added a production readiness runbook with 50ms SLO guidance.

Files: api_base_urls.csv, prod_api_readiness.md